### PR TITLE
Fixed snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,10 +132,10 @@ parts:
     after: [cups, pappl, libcupsfilters, libppd]
 
   qpdf:
-    source: https://github.com/qpdf/qpdf/releases/download/release-qpdf-10.6.3/qpdf-10.6.3.tar.gz
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=/usr
+    source: https://github.com/qpdf/qpdf/releases/download/v11.2.0/qpdf-11.2.0.tar.gz
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     build-packages:
       - g++
       - zlib1g-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,7 +132,7 @@ parts:
     after: [cups, pappl, libcupsfilters, libppd]
 
   qpdf:
-    source: https://github.com/qpdf/qpdf/releases/download/v11.2.0/qpdf-11.2.0.tar.gz
+    source: https://github.com/qpdf/qpdf/releases/download/v11.3.0/qpdf-11.3.0.tar.gz
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -136,6 +136,7 @@ parts:
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DCMAKE_INSTALL_PREFIX:PATH=/usr
     build-packages:
       - g++
       - zlib1g-dev


### PR DESCRIPTION
1) Snap was initially building qpdf 10.3.6 which was conflicting with current master of libcupsfilters which requires qpdf>=11.0
2) Qpdf initially used autotools for build, which was changed to cmake in version 11.2.0
