### PR TITLE
[Add]: Snap Update Automation

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,20 @@
+name: Push new tag update to stable branch
+
+on:
+  schedule:
+    # Daily for now
+    - cron: '9 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-snapcraft-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+      - name: Run desktop-snaps action  
+        uses: ubuntu/desktop-snaps@stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -621,7 +621,7 @@ parts:
     # Debian source
     source: https://salsa.debian.org/printing-team/hplip.v2.git
     source-type: git
-    source-branch: master/main
+    source-branch: debian/3.22.10+dfsg0-2
     source-depth: 1 
     # Excluding hplip from the update automation process because the UpdateSnap script is
     # unable to retrieve the source-tag or source-branch for this repository.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -620,7 +620,7 @@ parts:
     # Debian source
     source: https://salsa.debian.org/printing-team/hplip.v2.git
     source-type: git
-    source-tag: debian/3.22.10+dfsg0-2
+    source-tag: 'debian/3.22.10+dfsg0-4'
     source-depth: 1 
     # Excluding hplip from the update automation process because the UpdateSnap script is
     # unable to retrieve the source-tag or source-branch for this repository.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,8 +38,12 @@ parts:
   pappl:
     source: https://github.com/michaelrsweet/pappl
     source-type: git
+    source-tag: 'v1.4.4'
     source-depth: 1
-    source-tag: v1.4.2
+# ext:updatesnap
+#   version-format:
+#     lower-than: '2'
+#     no-9x-revisions: true
     plugin: autotools
     override-build: |
       set -eux
@@ -101,7 +105,13 @@ parts:
   pappl-retrofit:
     source: https://github.com/openprinting/pappl-retrofit
     source-type: git
+    source-tag: '1.0b2'
     source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     format: '%M.%m%R'
+#     lower-than: '2'
+#     no-9x-revisions: true
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
@@ -139,7 +149,14 @@ parts:
     after: [cups, pappl, libcupsfilters, libppd]
 
   qpdf:
-    source: https://github.com/qpdf/qpdf/releases/download/v11.4.0/qpdf-11.4.0.tar.gz
+    source: https://github.com/qpdf/qpdf/
+    source-type: git
+    source-tag: 'v11.7.0'
+    source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     lower-than: '12'
+#     no-9x-revisions: true
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/
@@ -181,7 +198,16 @@ parts:
       - -usr/lib/pkgconfig
 
   ghostscript:
-    source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10012/ghostscript-10.01.2.tar.gz
+    #source: https://git.ghostscript.com/ghostpdl.git
+    source: https://github.com/ArtifexSoftware/ghostpdl.git
+    source-type: git
+    source-tag: 'ghostpdl-10.02.1'
+    source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     format: "ghostpdl-%M.%m.%R"
+#     lower-than: '11'
+#     no-9x-revisions: true
     plugin: autotools
     # We only need PostScript output, for converting PDF input
     autotools-configure-parameters:
@@ -219,8 +245,12 @@ parts:
   cups:
     source: https://github.com/OpenPrinting/cups
     source-type: git
+    source-tag: 'v2.4.7'
     source-depth: 1
-    source-tag: v2.4.7
+# ext:updatesnap
+#   version-format: 
+#     lower-than: '3'
+#     no-9x-revisions: true
     plugin: autotools
     # We only need libcups (with headers, ...) and the backends
     override-build: |
@@ -304,7 +334,12 @@ parts:
   libcupsfilters:
     source: https://github.com/OpenPrinting/libcupsfilters
     source-type: git
+    source-tag: '2.0.0'
     source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     lower-than: '3'
+#     no-9x-revisions: true
     plugin: autotools
     # We only need libcupsfilters itself. so we simply do not prime the
     # auxiliary files (/usr/share)
@@ -369,7 +404,12 @@ parts:
   libppd:
     source: https://github.com/OpenPrinting/libppd
     source-type: git
+    source-tag: '2.0.0'
     source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     lower-than: '3'
+#     no-9x-revisions: true
     plugin: autotools
     # We only need libppd itself, so we also do not prime the auxiliary files
     # here.
@@ -411,7 +451,12 @@ parts:
   cups-filters:
     source: https://github.com/OpenPrinting/cups-filters
     source-type: git
+    source-tag: '2.0.0'
     source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     lower-than: '3'
+#     no-9x-revisions: true
     plugin: autotools
     # To find the libraries built in this Snap
     build-environment:
@@ -474,7 +519,13 @@ parts:
   pyppd:
     source: https://github.com/OpenPrinting/pyppd
     source-type: git
+    source-tag: 'release-1-1-0'
     source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     format: "release-%M-%m-%R"
+#     lower-than: '2'
+#     no-9x-revisions: true
     plugin: python
     override-prime: ""
 
@@ -482,6 +533,11 @@ parts:
     source: https://github.com/OpenPrinting/foomatic-db
     source-type: git
     source-depth: 1
+    # Excluding foomatic-git from the update automation process
+    # as it lacks any official releases.
+# ext:updatesnap
+#   version-format:
+#     ignore: true
     plugin: nil
     override-pull: |
       set -eux
@@ -565,8 +621,13 @@ parts:
     # Debian source
     source: https://salsa.debian.org/printing-team/hplip.v2.git
     source-type: git
-    source-branch: debian/3.22.10+dfsg0-2
-    source-depth: 1
+    source-branch: master/main
+    source-depth: 1 
+    # Excluding hplip from the update automation process because the UpdateSnap script is
+    # unable to retrieve the source-tag or source-branch for this repository.
+# ext:updatesnap
+#   version-format:
+#     ignore: true
     # Upstream source
     #source: https://sourceforge.net/projects/hplip/files/hplip/3.22.10/hplip-3.22.10.tar.gz
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,9 +109,7 @@ parts:
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     format: '%M.%m%R'
-#     lower-than: '2'
-#     no-9x-revisions: true
+#     format: '%V'
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
@@ -532,12 +530,13 @@ parts:
   foomatic-db:
     source: https://github.com/OpenPrinting/foomatic-db
     source-type: git
+    source-tag: '20240109'
     source-depth: 1
     # Excluding foomatic-git from the update automation process
     # as it lacks any official releases.
 # ext:updatesnap
 #   version-format:
-#     ignore: true
+#     format: '%V'
     plugin: nil
     override-pull: |
       set -eux
@@ -627,7 +626,7 @@ parts:
     # unable to retrieve the source-tag or source-branch for this repository.
 # ext:updatesnap
 #   version-format:
-#     ignore: true
+#     format: 'debian/%V'
     # Upstream source
     #source: https://sourceforge.net/projects/hplip/files/hplip/3.22.10/hplip-3.22.10.tar.gz
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -151,7 +151,7 @@ parts:
   qpdf:
     source: https://github.com/qpdf/qpdf/
     source-type: git
-    source-tag: 'v11.7.0'
+    source-tag: 'v11.8.0'
     source-depth: 1
 # ext:updatesnap
 #   version-format:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -620,7 +620,7 @@ parts:
     # Debian source
     source: https://salsa.debian.org/printing-team/hplip.v2.git
     source-type: git
-    source-branch: debian/3.22.10+dfsg0-2
+    source-tag: debian/3.22.10+dfsg0-2
     source-depth: 1 
     # Excluding hplip from the update automation process because the UpdateSnap script is
     # unable to retrieve the source-tag or source-branch for this repository.


### PR DESCRIPTION
- Integrated the GitHub workflow auto-update.yml located in .github/workflows/ from the https://github.com/ubuntu/desktop-snaps repository. This leverages the GitHub action for automating updates to the snapcraft.yaml file.

- Modified the snapcraft.yaml file to enable the update automation for the individual parts.

- It's currently not feasible to automate updates for foomatic-db releases due to the absence of official releases for foomatic-db. Additionally, excluded hplip from the update process since the script couldn't retrieve source-tag and source-branch information for this repository.