### PR TITLE
[Fixes] build fail in snap store

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,7 +105,7 @@ parts:
   pappl-retrofit:
     source: https://github.com/openprinting/pappl-retrofit
     source-type: git
-    source-tag: '1.0b2'
+    # source-tag: '1.0b2'
     source-depth: 1
 # ext:updatesnap
 #   version-format:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
     source-depth: 1
 # ext:updatesnap
 #   version-format:
+#     ignore: true
 #     format: '%V'
     plugin: autotools
     autotools-configure-parameters:


### PR DESCRIPTION
- commented source-tag in pappl-retrofit
- excluded pappl-retrofit part from auto tag updation