### PR TITLE
[Fixes] `registry-actions.yml` workflow

### DIFF
--- a/.github/workflows/registry-actions.yml
+++ b/.github/workflows/registry-actions.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Pack with Rockcraft
         uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
-        with:
-          path: rock
 
       - name: Upload Rock Artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -313,12 +313,12 @@ Then run the following Docker command to run the ps-printer-app image in a conta
   sudo docker run --rm -d \
       --name ps-printer-app \
       --network host \
-      -e PORT:<port> \
+      -e PORT=<port> \
       openprinting/ps-printer-app:latest
 ```
 - `PORT` is an optional environment variable used to start the printer-app on a specified port. If not provided, it will start on the default port 8000 or, if port 8000 is busy, on 8001 and so on.
 - **The container must be started in `--network host` mode** to allow the Printer-Application instance inside the container to access and discover printers available in the local network where the host system is in.
-- Alternatively using the internal network of the Docker instance (`-p <port>:8000` instead of `--network host -e PORT:<port>`) only gives access to local printers running on the host system itself.
+- Alternatively using the internal network of the Docker instance (`-p <port>:8000` instead of `--network host -e PORT=<port>`) only gives access to local printers running on the host system itself.
 
 ### Setting up and running a ps-printer-app container locally
 
@@ -360,12 +360,12 @@ sudo rockcraft.skopeo --insecure-policy copy oci-archive:<rock_image> docker-dae
   sudo docker run --rm -d \
       --name ps-printer-app \
       --network host \
-      -e PORT:<port> \
+      -e PORT+<port> \
       ps-printer-app:latest
 ```
 - `PORT` is an optional environment variable used to start the printer-app on a specified port. If not provided, it will start on the default port 8000 or, if port 8000 is busy, on 8001 and so on.
 - **The container must be started in `--network host` mode** to allow the Printer-Application instance inside the container to access and discover printers available in the local network where the host system is in.
-- Alternatively using the internal network of the Docker instance (`-p <port>:8000` instead of `--network host -e PORT:<port>`) only gives access to local printers running on the host system itself.
+- Alternatively using the internal network of the Docker instance (`-p <port>:8000` instead of `--network host -e PORT=<port>`) only gives access to local printers running on the host system itself.
 
 #### Setting up
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ sudo rockcraft.skopeo --insecure-policy copy oci-archive:<rock_image> docker-dae
   sudo docker run --rm -d \
       --name ps-printer-app \
       --network host \
-      -e PORT+<port> \
+      -e PORT=<port> \
       ps-printer-app:latest
 ```
 - `PORT` is an optional environment variable used to start the printer-app on a specified port. If not provided, it will start on the default port 8000 or, if port 8000 is busy, on 8001 and so on.


### PR DESCRIPTION
- Fixed `rock` path in `registry-actions.yml` workflow
- Updated:README instructions to correctlt pass env variable (PORT) in container