### PR TITLE
Enhance auto-update.yml Workflow and Update Base OS for Rock Builds

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -38,3 +38,4 @@ jobs:
           repo: ${{ github.repository }}
           rock-version-schema: '^(\d{8})'
           yaml-path: 'rockcraft.yaml'
+          readme-path: 'README.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-rock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/registry-actions.yml
+++ b/.github/workflows/registry-actions.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-rock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ make and model. Also set the installed accessories, loaded media and
 the option defaults. Accessory configuration and option defaults can
 also often get polled from the printer.
 
+<!-- Begin Included Components -->
+
+<!-- End Included Components -->
+
 ## BUILDING WITHOUT PACKAGING OR INSTALLATION
 
 You can also do a "quick-and-dirty" build without snapping and without


### PR DESCRIPTION
This PR introduces the following improvements:  

- Enhanced the `auto-update.yml` workflow to automatically update the README file with a list of parts and their corresponding versions, leveraging the latest changes from the ubuntu/desktop-snaps/pull/840.  
- Updated the base OS to `ubuntu-22.04` in all workflows requiring Rock builds.